### PR TITLE
Remove pytest.ini and remove unnecessary stuff from .yamllint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.python-version

--- a/.yamllint
+++ b/.yamllint
@@ -1,13 +1,6 @@
 extends: default
 
 rules:
-  braces:
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
-  line-length: disable
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable

--- a/molecule/default/pytest.ini
+++ b/molecule/default/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:cacheprovider -p no:stepwise


### PR DESCRIPTION
`pytest.ini` is no longer necessary with version 3.10.1 of `pytest`.