### PR TITLE
Rotate rsyslog log files daily

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,4 +1,13 @@
 ---
+# rsyslog is already installed on the AMIs we are using
+- name: Create
+  hosts: all
+  tasks:
+    - name: Install rsyslog
+      package:
+        name: rsyslog
+        state: present
+
 - name: Converge
   hosts: all
   roles:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -29,3 +29,15 @@ def test_files(host, file, content):
 
     assert f.exists
     assert f.contains(content)
+
+
+@pytest.mark.parametrize('file,content', [
+    ('/etc/logrotate.d/rsyslog', '^\s*daily'),
+    ('/etc/logrotate.d/rsyslog', '^\s*rotate 7'),
+])
+def test_rsyslog_file(host, file, content):
+    f = host.file(file)
+
+    # The file only exists on Debian systems
+    if f.exists:
+        assert f.contains(content)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     - regex: '^#compress'
       line: compress
 
-# Redhat stores similar configuration information in
+# Amazon Linux (Red Hat) stores similar configuration information in
 # /etc/logrotate.d/syslog, but there the files are already rotated
 # daily.
 - name: Modify rsyslog configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,26 @@
     - regex: '^#compress'
       line: compress
 
+# Redhat stores similar configuration information in
+# /etc/logrotate.d/syslog, but there the files are already rotated
+# daily.
+- name: Modify rsyslog configuration
+  lineinfile:
+    dest: /etc/logrotate.d/rsyslog
+    regexp: "{{item.regex}}"
+    state: present
+    line: "{{item.line}}"
+    backrefs: yes
+  loop:
+    # Rotate log files daily
+    - regex: '\s*weekly'
+      line: '\tdaily'
+    # Keep seven days worth of logs
+    - regex: '\s*rotate'
+      line: '\trotate 7'
+  when:
+    - ansible_os_family == "Debian"
+
 - name: Install cyhy-specific logrotate configuration
   copy:
     src: cyhy


### PR DESCRIPTION
We have been running out of space on the root disk of the CyHy MongoDB instance.  The problem appears to be that the `rsyslog` log files are only rotated weekly.  In particular, the daemon log file grows to 7GB in a week.

This pull request modifies the `rsyslog` `logrotate` configuration to rotate daily and only keep a week of backups.  This change is only applied to the Debian hosts because the Amazon linux hosts are already configured this way by default.